### PR TITLE
🔒 [security fix] Bounded file read for configuration files

### DIFF
--- a/src/config/favorites.rs
+++ b/src/config/favorites.rs
@@ -20,7 +20,7 @@ impl FavoritesConfig {
     /// Load favorites from disk, falling back to an empty list on any error.
     pub fn load() -> Self {
         if let Some(path) = Self::config_path()
-            && let Ok(data) = std::fs::read_to_string(&path)
+            && let Ok(data) = crate::config::read_to_string_limited(&path, 1_000_000)
             && let Ok(cfg) = serde_json::from_str::<Self>(&data)
         {
             return cfg;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,49 @@
 pub mod favorites;
 pub mod parser;
 pub mod theme;
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+
+/// Reads a file into a string with a maximum size limit.
+/// Returns an error if the file exceeds the limit.
+pub fn read_to_string_limited<P: AsRef<Path>>(path: P, limit: u64) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    let mut buffer = Vec::new();
+    // Try to read up to limit + 1 bytes
+    let n = file.take(limit + 1).read_to_end(&mut buffer)?;
+    if n > limit as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+    String::from_utf8(buffer).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_to_string_limited_ok() -> io::Result<()> {
+        let mut file = NamedTempFile::new()?;
+        writeln!(file, "Hello, world!")?;
+        let content = read_to_string_limited(file.path(), 100)?;
+        assert_eq!(content, "Hello, world!\n");
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_to_string_limited_too_large() -> io::Result<()> {
+        let mut file = NamedTempFile::new()?;
+        writeln!(file, "This is a long sentence that should exceed the limit.")?;
+        let result = read_to_string_limited(file.path(), 10);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("File exceeds size limit"));
+        Ok(())
+    }
+}

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -12,8 +12,8 @@ use crate::effects::Pipeline;
 /// Files with no recognised extension are tried as YAML first, then JSON.
 pub fn load_pipeline(path: &Path) -> Result<Pipeline> {
     log::info!("Loading pipeline from {}", path.display());
-    let contents =
-        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let contents = crate::config::read_to_string_limited(path, 10_000_000)
+        .with_context(|| format!("reading {}", path.display()))?;
     let ext = path
         .extension()
         .and_then(|e| e.to_str())

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -60,7 +60,7 @@ impl Default for Theme {
 impl Theme {
     pub fn load_from_path(path: &Path) -> Self {
         let mut theme = Self::default();
-        if let Ok(contents) = std::fs::read_to_string(path) {
+        if let Ok(contents) = crate::config::read_to_string_limited(path, 1_000_000) {
             if let Ok(config) = serde_json::from_str::<ThemeConfig>(&contents) {
                 if let Some(c) = config.active_border.and_then(|s| Color::from_str(&s).ok()) {
                     theme.active_border = c;


### PR DESCRIPTION
### 🎯 What
Fixed an "Unbounded File Read" vulnerability in the configuration loading logic.

### ⚠️ Risk
A local user could cause a Denial of Service (DoS) by placing a very large file in the application's configuration directory (e.g., `~/.config/spix/theme.json`). When the application starts, it would attempt to read the entire file into a `String` using `std::fs::read_to_string`, potentially leading to an Out-of-Memory (OOM) crash.

### 🛡️ Solution
Introduced a new helper function `read_to_string_limited` in `src/config/mod.rs` that uses `std::io::Read::take` to enforce a hard limit on the number of bytes read from a file. 
- Theme and Favorites configurations are now limited to 1MB.
- Effect pipelines are limited to 10MB.
These limits are far beyond what's needed for legitimate configuration files but provide a safety net against malicious inputs.


---
*PR created automatically by Jules for task [14037452418392344560](https://jules.google.com/task/14037452418392344560) started by @gioleppe*