### PR TITLE
🧪 [testing improvement] Add tests for ExportFormat in engine/export.rs

### DIFF
--- a/src/engine/export.rs
+++ b/src/engine/export.rs
@@ -107,3 +107,24 @@ pub(crate) fn safe_path(mut path: PathBuf) -> PathBuf {
         n += 1;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_export_format_extension() {
+        assert_eq!(ExportFormat::Png.extension(), "png");
+        assert_eq!(ExportFormat::Jpeg { quality: 90 }.extension(), "jpg");
+        assert_eq!(ExportFormat::WebP.extension(), "webp");
+        assert_eq!(ExportFormat::Bmp.extension(), "bmp");
+    }
+
+    #[test]
+    fn test_export_format_display_name() {
+        assert_eq!(ExportFormat::Png.display_name(), "PNG");
+        assert_eq!(ExportFormat::Jpeg { quality: 90 }.display_name(), "JPEG");
+        assert_eq!(ExportFormat::WebP.display_name(), "WebP");
+        assert_eq!(ExportFormat::Bmp.display_name(), "BMP");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `ExportFormat` in `src/engine/export.rs` has been addressed by adding unit tests for its methods.
📊 **Coverage:** The new tests cover both `extension()` and `display_name()` for all supported variants: `Png`, `Jpeg`, `WebP`, and `Bmp`.
✨ **Result:** Increased test coverage ensures that file extensions and display names remain correct and consistent, preventing regressions in the export logic.

---
*PR created automatically by Jules for task [16945031215995485228](https://jules.google.com/task/16945031215995485228) started by @gioleppe*