### PR TITLE
🧪 Add unit tests for `format_param_value`

### DIFF
--- a/src/app/pipeline_utils.rs
+++ b/src/app/pipeline_utils.rs
@@ -384,3 +384,24 @@ pub fn format_param_value(value: f32) -> String {
         format!("{value}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_param_value_integers() {
+        assert_eq!(format_param_value(8.0), "8");
+        assert_eq!(format_param_value(0.0), "0");
+        assert_eq!(format_param_value(-5.0), "-5");
+        assert_eq!(format_param_value(42.0), "42");
+    }
+
+    #[test]
+    fn test_format_param_value_fractions() {
+        assert_eq!(format_param_value(1.5), "1.5");
+        assert_eq!(format_param_value(0.05), "0.05");
+        assert_eq!(format_param_value(-3.14), "-3.14");
+        assert_eq!(format_param_value(0.999), "0.999");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `format_param_value` utility function located in `src/app/pipeline_utils.rs`.
📊 **Coverage:** The scenarios now tested include integer formatting (checking that whole numbers like `8.0`, `0.0`, `-5.0` format without decimal places) and fractional formatting (checking that numbers with decimal components like `1.5`, `0.05`, `-3.14` preserve their shortest-round-trip representation).
✨ **Result:** The improvement in test coverage guarantees that this specific string formatting logic will correctly handle floats moving forward, adding regression safety.

---
*PR created automatically by Jules for task [9336659868335852586](https://jules.google.com/task/9336659868335852586) started by @gioleppe*